### PR TITLE
Fixed submit approach for feedback and small improvements

### DIFF
--- a/jspdocportal-module/src/main/java/org/mycore/frontend/jsp/taglibs/MCROutputNavigationTag.java
+++ b/jspdocportal-module/src/main/java/org/mycore/frontend/jsp/taglibs/MCROutputNavigationTag.java
@@ -350,7 +350,6 @@ public class MCROutputNavigationTag extends MCRAbstractNavigationTag {
                             out.append(INDENT).append("</li>");
                         }
                     }
-                    out.append(INDENT).append("   </ul>");
                     if (getJspBody() != null) {
                         getJspBody().invoke(out);
                     }

--- a/jspdocportal-module/src/main/resources/META-INF/resources/WEB-INF/views/webpage.jsp
+++ b/jspdocportal-module/src/main/resources/META-INF/resources/WEB-INF/views/webpage.jsp
@@ -41,7 +41,7 @@
           </div>
        </c:if>
         <c:if test="${not empty requestScope['org.mycore.navigation.side.path']}">
-          <div class="col col-md-3 ir-content-side">
+          <div class="col col-md-3 ir-content-side" id="left-side-nav">
               <mcr:outputNavigation mode="side" id="${fn:substringBefore(requestScope['org.mycore.navigation.side.path'], '.')}"></mcr:outputNavigation>
               <c:if test="${not empty actionBean.infoBox}">
                 <mcr:includeWebcontent id="${fn:replace(actionBean.infoBox, '/', '.')}" file="${actionBean.infoBox}.html" />

--- a/jspdocportal-module/src/main/resources/META-INF/resources/content/feedback.jsp
+++ b/jspdocportal-module/src/main/resources/META-INF/resources/content/feedback.jsp
@@ -20,7 +20,7 @@
 				beanclass="org.mycore.frontend.jsp.stripes.actions.SendFeedbackAction"
 				id="feedback-form" enctype="multipart/form-data" acceptcharset="UTF-8"
 				class="form-horizontal ir-box">
-				<input name="csrfToken" type="hidden" id="csrf-token" value="" />
+				<stripes:hidden name="csrfToken">${actionBean.csrfToken}</stripes:hidden>
 				<stripes:hidden name="returnURL">${actionBean.returnURL}</stripes:hidden>
 				<stripes:hidden name="subject">${actionBean.subject}</stripes:hidden>
 				<stripes:hidden name="recipient">${actionBean.recipient}</stripes:hidden>
@@ -73,18 +73,10 @@
 					<label class="col-sm-2 control-label"></label>
 					<div class="col-sm-10">
 						<fmt:message key="Webpage.feedback.button.send" var="lblSend" />
-						<input name="doSend" type="submit" id="submit-button" style="display:none" disabled="disabled" value="${lblSend}"  />
-					    <button class="btn btn-primary" onclick="submitForm('${actionBean.csrfToken}')">${lblSend}</button>
+						<input class="btn btn-primary" name="doSend" type="submit" id="submit-button" value="${lblSend}"  />
 					</div>
 				</div>
 			</stripes:form>
-			<script type="text/javascript">
-				function submitForm(csrf){
-					document.getElementById('csrf-token').value = csrf;
-					document.getElementById('submit-button').disabled=false;
-					document.getElementById('submit-button').click();
-				}
-			</script>
 		</div>
 	</stripes:layout-component>
 </stripes:layout-render>


### PR DESCRIPTION
Was there a special reason for the complicated csrf-token approach in feedback? Chrome and Safari have problems with this, but it works with Firefox. Specifically, the full form is not submitted. I have additionally introduced an id for the left navigation, which is may redundant with respect to a dropdown nav menu.